### PR TITLE
Branding Smite has a bonus action casting time

### DIFF
--- a/_posts/2015-01-07-branding-smite.markdown
+++ b/_posts/2015-01-07-branding-smite.markdown
@@ -8,7 +8,7 @@ tags: [paladin, level2, evocation]
 
 **2nd-level evocation**
 
-**Casting Time**: 1 action
+**Casting Time**: 1 bonus action
 
 **Range**: self
 


### PR DESCRIPTION
Branding Smite's casting time is given as 1 bonus action in PHB pg. 219/220, not 1 action.